### PR TITLE
Reduce Warnings on Visual Studio 2015 or newer.

### DIFF
--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -129,6 +129,8 @@ elseif(MSVC)
 	if(USE_MFC_TOOLS)
 		add_definitions(-D_AFXDLL)
 		add_definitions(-DUSE_MFC_TOOLS)
+		# Do not Warn about MFC.
+		add_definitions(-DNO_WARN_MBCS_MFC_DEPRECATION)
 		
 		# 0: Use Standard Windows Libraries
 		# 1: Use MFC in a Static Library
@@ -180,6 +182,7 @@ elseif(MSVC)
 					-D_CRT_NONSTDC_NO_DEPRECATE
 					-D_CRT_SECURE_NO_WARNINGS
 					-D_MBCS
+					-DSAL_NO_ATTRIBUTE_DECLARATIONS
 					#-DUSE_OPENAL
 					-DUSE_EXCEPTIONS)
 					
@@ -1164,7 +1167,7 @@ if(MSVC)
 	endif()
 
 	#endif()
-	
+
 	if(OPENAL)
 		add_definitions(-DUSE_OPENAL)
 	

--- a/neo/idlib/sys/sys_defines.h
+++ b/neo/idlib/sys/sys_defines.h
@@ -208,10 +208,25 @@ bulk of the codebase, so it is the best place for analyze pragmas.
 // win32 needs this, but 360 doesn't
 #pragma warning( disable: 6540 )	// warning C6540: The use of attribute annotations on this function will invalidate all of its existing __declspec annotations [D:\tech5\engine\engine-10.vcxproj]
 
+#if _MSC_VER < 1900
+/* Visual Studio 2015 or newer has this warning enabled by default.*/
+#pragma warning(enable: 4005)  /* macro redefinition */
+#endif
+#if _MSC_VER >= 1900
+//  non-member operator new or delete functions may not be declared inline
+#pragma warning( disable: 4595 )
+#endif
+
 
 // checking format strings catches a LOT of errors
 #include <CodeAnalysis\SourceAnnotations.h>
+
+
+#if _MSC_VER >= 1600
+#define	VERIFY_FORMAT_STRING	_SA_annotes1(SAL_IsFormatString, "printf")
+#else
 #define	VERIFY_FORMAT_STRING	[SA_FormatString(Style="printf")]
+#endif
 // DG: alternative for GCC with attribute (NOOP for MSVC)
 #define ATTRIBUTE_PRINTF(STRIDX, FIRSTARGIDX)
 

--- a/neo/sound/snd_local.h
+++ b/neo/sound/snd_local.h
@@ -167,9 +167,6 @@ struct AudioDevice
 #endif
 // RB end
 
-#ifdef _MSC_VER 
-#pragma warning( enable: 4005 )  /* macro redefinition */
-#endif
 #include "XAudio2/XA2_SoundSample.h"
 #include "XAudio2/XA2_SoundVoice.h"
 #include "XAudio2/XA2_SoundHardware.h"


### PR DESCRIPTION
The changes in this pull request are to greatly reduce the number of warnings when compiling with Visual Studio 2015 or newer.