### PR TITLE
Fix vehicle crash by serializing wheel constraint names.

### DIFF
--- a/neo/d3xp/AFEntity.cpp
+++ b/neo/d3xp/AFEntity.cpp
@@ -3389,6 +3389,8 @@ void idAFEntity_VehicleSimple_4wd::Spawn( void ) {
 										vehicleSuspensionDamping,
 										vehicleTireFriction );
 
+		wheelConstraints[i] = af.GetPhysics()->GetNumConstraints();
+
 		af.GetPhysics()->AddConstraint( suspension[i] );
 		
 		tempAngles[i] = 0.0f;	// ################## SR
@@ -3418,6 +3420,7 @@ void idAFEntity_VehicleSimple_4wd::Save( idSaveGame *savefile ) const {
    {
       savefile->WriteJoint(wheelJoints[wheel]);
       savefile->WriteFloat(wheelAngles[wheel]);
+	  savefile->WriteString(af.GetPhysics()->GetConstraint(wheelConstraints[wheel])->GetName().c_str());
    }
 }
 
@@ -3434,13 +3437,17 @@ void idAFEntity_VehicleSimple_4wd::Restore( idRestoreGame *savefile )
    {
 	   savefile->ReadJoint(wheelJoints[wheel]);
 	   savefile->ReadFloat(wheelAngles[wheel]);
+	   idStr constraintName;
+	   savefile->ReadString(constraintName);
+
+	   wheelConstraints[wheel] = af.GetPhysics()->GetConstraintId(constraintName.c_str());
 
 	   idVec3 origin;
 	   idMat3 axis;
 	   animator.GetJointTransform( wheelJoints[wheel], 0, origin, axis );
 	   origin = renderEntity.origin + origin * renderEntity.axis;
 
-	   suspension[wheel] = static_cast<idAFConstraint_Suspension *>(af.GetPhysics()->GetConstraint(wheel));
+	   suspension[wheel] = static_cast<idAFConstraint_Suspension *>(af.GetPhysics()->GetConstraint(wheelConstraints[wheel]));
 	   suspension[wheel]->Setup(va("suspension%d", wheel), af.GetPhysics()->GetBody(0), wheelModel);
 	   suspension[wheel]->SetPosition(origin, af.GetPhysics()->GetAxis(0));
 	   	   
@@ -3467,6 +3474,7 @@ void idAFEntity_VehicleSimple_4wd::RecreateDynamicConstraints( idList<idAFConstr
 	int i;
 	for(i=0;i<4;i++) {
          idAFConstraint_Suspension *constraint = new idAFConstraint_Suspension();
+		 constraint->Setup(va("suspension%d", i), NULL, NULL);
          //constraint->physics = af.GetPhysics();
          constraints->Append(constraint);
 		 

--- a/neo/d3xp/AFEntity.h
+++ b/neo/d3xp/AFEntity.h
@@ -547,6 +547,7 @@ protected:
 	idAFConstraint_Suspension *	suspension[4];
 	jointHandle_t				wheelJoints[4];
 	float						wheelAngles[4];
+	int						wheelConstraints[4];
 	
 	float						tempAngles[4];	// #### SR
 	idVec3 						wheelorigin[4];	// #### SR


### PR DESCRIPTION
There's other approaches you could take, but, this one is probably the simplest. This will work as long as the constraint names stay consistent in the code.